### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/ide-service/src/main/resources/changelog/ide-rdbms.db.changelog.xml
+++ b/ide-service/src/main/resources/changelog/ide-rdbms.db.changelog.xml
@@ -33,6 +33,7 @@
   </changeSet>
 
   <changeSet author="ide" id="1.0.0-1">
+    <validCheckSum>9:07e7a0dc374c7052790a31d52783af01</validCheckSum>
     <createTable tableName="IDE_WIDGETS">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_IDE_WIDGETS"/>
@@ -47,7 +48,7 @@
       <column name="CREATED_DATE" type="TIMESTAMP"/>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -56,6 +57,12 @@
         ALTER TABLE IDE_WIDGETS MODIFY COLUMN HTML LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
         ALTER TABLE IDE_WIDGETS MODIFY COLUMN CSS LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
         ALTER TABLE IDE_WIDGETS MODIFY COLUMN JS LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
+  <changeSet author="ide" id="1.0.0-3" >
+    <sql dbms="mysql">
+      ALTER TABLE IDE_WIDGETS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
     </sql>
   </changeSet>
 


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. 
This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564
