### PR TITLE
fix: Improve Widget JS parsing - MEED-8431 - Meeds-io/meeds#2949

### DIFF
--- a/ide-service/src/main/java/io/meeds/ide/rest/WidgetRest.java
+++ b/ide-service/src/main/java/io/meeds/ide/rest/WidgetRest.java
@@ -52,12 +52,10 @@ public class WidgetRest {
   private WidgetService             widgetService;
 
   @GetMapping("{id}")
-  @Operation(summary = "Retrieve a Web application widget",
-             method = "GET",
-             description = "This will retrieve a page template designated by its id")
+  @Operation(summary = "Retrieve a Web application widget", method = "GET", description = "This will retrieve a page template designated by its id")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "404", description = "Widget not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Widget not found"),
   })
   public Widget getWidget(
                           @Parameter(description = "Widget identifier")
@@ -71,12 +69,10 @@ public class WidgetRest {
   }
 
   @GetMapping("{id}/html")
-  @Operation(summary = "Retrieve a Web application widget html",
-             method = "GET",
-             description = "Retrieve a Web application widget html")
+  @Operation(summary = "Retrieve a Web application widget html", method = "GET", description = "Retrieve a Web application widget html")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "404", description = "Widget not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Widget not found"),
   })
   public ResponseEntity<String> getWidgetHtml(
                                               HttpServletRequest request,
@@ -95,12 +91,10 @@ public class WidgetRest {
   }
 
   @GetMapping("{id}/css")
-  @Operation(summary = "Retrieve a Web application widget css",
-             method = "GET",
-             description = "Retrieve a Web application widget css")
+  @Operation(summary = "Retrieve a Web application widget css", method = "GET", description = "Retrieve a Web application widget css")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "404", description = "Widget not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Widget not found"),
   })
   public ResponseEntity<String> getWidgetCss(
                                              HttpServletRequest request,
@@ -119,12 +113,10 @@ public class WidgetRest {
   }
 
   @GetMapping("{id}/js")
-  @Operation(summary = "Retrieve a Web application widget javascript",
-             method = "GET",
-             description = "Retrieve a Web application widget javascript")
+  @Operation(summary = "Retrieve a Web application widget javascript", method = "GET", description = "Retrieve a Web application widget javascript")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "404", description = "Widget not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Widget not found"),
   })
   public ResponseEntity<String> getWidgetJs(
                                             HttpServletRequest request,
@@ -136,7 +128,7 @@ public class WidgetRest {
       return ResponseEntity.ok()
                            .cacheControl(CACHE_CONTROL)
                            .contentType(MediaType.parseMediaType("text/javascript"))
-                           .body(widget.getJs());
+                           .body("(function() {"+ widget.getJs() +"})()");
     } catch (ObjectNotFoundException e) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
     }
@@ -146,9 +138,9 @@ public class WidgetRest {
   @Secured("administrators")
   @Operation(summary = "Delete a Web application widget ", method = "DELETE", description = "This deletes a Web application widget")
   @ApiResponses(value = {
-          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-          @ApiResponse(responseCode = "403", description = "Forbidden"),
-          @ApiResponse(responseCode = "404", description = "Not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "403", description = "Forbidden"),
+    @ApiResponse(responseCode = "404", description = "Not found"),
   })
   public void deleteWidget(HttpServletRequest request,
                            @Parameter(description = "Widget id", required = true)
@@ -165,13 +157,11 @@ public class WidgetRest {
 
   @PutMapping("{id}")
   @Secured("administrators")
-  @Operation(summary = "Update an existing a Web application widget",
-             method = "PUT",
-             description = "Update an existing a Web application widget")
+  @Operation(summary = "Update an existing a Web application widget", method = "PUT", description = "Update an existing a Web application widget")
   @ApiResponses(value = {
-                          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-                          @ApiResponse(responseCode = "403", description = "Forbidden"),
-                          @ApiResponse(responseCode = "404", description = "Not found"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "403", description = "Forbidden"),
+    @ApiResponse(responseCode = "404", description = "Not found"),
   })
   public void updateWidget(
                            HttpServletRequest request,

--- a/ide-service/src/test/java/io/meeds/ide/rest/WidgetRestTest.java
+++ b/ide-service/src/test/java/io/meeds/ide/rest/WidgetRestTest.java
@@ -186,7 +186,7 @@ public class WidgetRestTest {
     when(widget.getJs()).thenReturn(JS_CONTENT);
     ResultActions response = mockMvc.perform(get(REST_PATH + "/2/js"));
     response.andExpect(status().isOk())
-            .andExpect(content().string(JS_CONTENT))
+            .andExpect(content().string("(function() {"+ JS_CONTENT +"})()"))
             .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "text/javascript"));
   }
 

--- a/ide-webapp/src/main/resources/locale/portlet/WidgetEditor_en.properties
+++ b/ide-webapp/src/main/resources/locale/portlet/WidgetEditor_en.properties
@@ -4,3 +4,4 @@ codeEditor.save=Save
 codeEditor.savedSuccessfully=Widget saved successfully
 codeEditor.saveError=Error saving widget
 codeEditor.switchDisplayMode=Switch display mode
+codeEditor.jsExecutionError=An error occurred while executing the JS code

--- a/ide-webapp/src/main/webapp/vue-app/site-management-extension/components/StaticResourceFormDialog.vue
+++ b/ide-webapp/src/main/webapp/vue-app/site-management-extension/components/StaticResourceFormDialog.vue
@@ -250,8 +250,18 @@ export default {
       }
       if (this.js) {
         const scriptElement = document.createElement('script');
-        scriptElement.innerText = this.js;
+        window.ideJsCodeExecuted = false;
+        scriptElement.innerText = `
+          function() {
+            ${this.js}
+          })();
+          window.ideJsCodeExecuted = true;
+        `;
         this.$refs.code.append(scriptElement);
+        if (!window.ideJsCodeExecuted) {
+          console.error('An error occurred in JS code execution, please make sure adding semicolons in JS');
+          this.$root.$emit('alert-message', 'warning', this.$t('codeEditor.jsExecutionError'));
+        }
       }
       this.modified = false;
     },

--- a/ide-webapp/src/main/webapp/vue-app/widget-editor/components/view/CodeViewer.vue
+++ b/ide-webapp/src/main/webapp/vue-app/widget-editor/components/view/CodeViewer.vue
@@ -118,9 +118,19 @@ export default {
         this.$refs.code.append(htmlElement);
       }
       if (this.js) {
+        window.ideJsCodeExecuted = false;
         const scriptElement = document.createElement('script');
-        scriptElement.innerText = this.js;
+        scriptElement.innerHTML = `
+          (function() {
+            ${this.js}
+          })();
+          window.ideJsCodeExecuted = true;
+        `;
         this.$refs.code.append(scriptElement);
+        if (!window.ideJsCodeExecuted) {
+          console.error('An error occurred in JS code execution, please make sure adding semicolons in JS');
+          this.$root.$emit('alert-message', this.$t('codeEditor.jsExecutionError'), 'warning');
+        }
       }
       this.modified = false;
     },


### PR DESCRIPTION
Prior to this change, when having a missing semicolon or a const in the JS code, the code isn't executed and an error is thrown for the IDE Widget in Edit Mode. This change ensures to parse the JS without introducing a <br> element into it in order to keep the Javascript engine execute it without strict parsing mode. In addition, this change will encapsulate the JS code in a specific execution context in order to allow redefining the same const multiple time in multiple instances in the same page rather than letting the global context used.

Resolves Meeds-io/meeds#2949