### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/ide-service/src/main/java/io/meeds/ide/listener/StaticResourcesAnalyticsListener.java
+++ b/ide-service/src/main/java/io/meeds/ide/listener/StaticResourcesAnalyticsListener.java
@@ -62,8 +62,8 @@ public class StaticResourcesAnalyticsListener extends Listener<String, Widget> {
     statisticData.setSubModule("layout");
     statisticData.setOperation("addStatisticResource");
     statisticData.setUserId(widget.getCreatorId());
-    statisticData.addParameter(SITE_NAME, widget.getProperties().get(SITE_NAME));
-    statisticData.addParameter(STATISTICS_TYPE_PARAM, widget.getType());
+    statisticData.addKeyword(SITE_NAME, widget.getProperties().get(SITE_NAME));
+    statisticData.addKeyword(STATISTICS_TYPE_PARAM, widget.getType());
     addStatisticData(statisticData);
   }
 }


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.